### PR TITLE
On a rename of a ff from one that is randomly generted to one that is…

### DIFF
--- a/passes/cmds/rename.cc
+++ b/passes/cmds/rename.cc
@@ -99,7 +99,11 @@ static IdString derive_name_from_cell_output_wire(const RTLIL::Cell *cell)
 		}
 	}
 
-	return name + cell->type.str();
+	//return name + cell->type.str();
+        
+        // we need the trailing "_reg" here because names need to be unique across _all_
+        // wires, memories, cells, and processes inside a module.
+	return name + "_reg";
 }
 
 struct RenamePass : public Pass {


### PR DESCRIPTION
… inherited from the user named wire that it drives, change the suffix from the ff library cell name to just '_reg'.  This is done for simplicity and uniformity